### PR TITLE
add custom type hint

### DIFF
--- a/src/AutoRoute.php
+++ b/src/AutoRoute.php
@@ -174,9 +174,13 @@ class AutoRoute
         foreach ($method->getParameters() as $param) {
             $paramName = $param->getName();
             $typeHint = $param->hasType() ? $param->getType()->getName() : null;
-            if (!in_array($typeHint, ['int', 'float', 'string', 'bool']) && $typeHint !== null) {
-                continue;
+
+            if ($typeHint !== null && class_exists($typeHint)) {
+                if (!in_array($typeHint, ['int', 'float', 'string', 'bool']) && !in_array($typeHint, $patterns)) {
+                    continue;
+                }
             }
+
             $routePatterns[$paramName] = $patterns[$paramName] ??
                 ($this->defaultPatterns[":{$typeHint}"] ?? $this->defaultPatterns[':any']);
             $endpoints[] = $param->isOptional() ? "{{$paramName}?}" : "{{$paramName}}";


### PR DESCRIPTION
If there is another way, I apologize for this PR, but this contribution is to be able to add Model as type hint:
file `auto-route.php`
```
'patterns'     => [
    'slug'     => '([\w\-_]+)',
    'uuid'     => '([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
    'date'     => '([0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]))',
    "customer" => "App\Models\Customer",
],
```
![Captura de Tela 2021-05-23 às 12 54 34](https://user-images.githubusercontent.com/5748703/119267695-18dd3100-bbc6-11eb-8bda-5364fc0f2b26.png)

in controller

```
public function getShow(Customer $customer){}
```